### PR TITLE
Add option to add provider with hawkular metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This Ansible module provides different ManageIQ operations. 
 
 
-### prerequisites
+### Prerequisites
 
 ManageIQ Python API Client package [manageiq-api-client-python] (https://github.com/ManageIQ/manageiq-api-client-python/).
 
@@ -14,6 +14,5 @@ ManageIQ Python API Client package [manageiq-api-client-python] (https://github.
 Currently, the module supports adding an OpenShift containers provider to manageiq.
 An example playbook `add_provider.yml` is provided and can be run by:
 
-    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin url=http://localhost:3000 hostname=oshift01.com port=8443 username=user password=****** token=******"
-
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin url=http://localhost:3000 hostname=oshift01.com port=8443 username=user password=****** token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
 

--- a/add_provider.yml
+++ b/add_provider.yml
@@ -12,6 +12,9 @@
       hostname: '{{ hostname }}'
       port: '{{ port }}'
       token: '{{ token }}'
+      metrics: '{{ metrics | default(omit) }}'
+      hawkular_hostname: '{{ hawkular_hostname | default(omit) }}'
+      hawkular_port: '{{ hawkular_port | default(omit) }}'
     register: result
 
   - debug: var=result

--- a/library/manageiq.py
+++ b/library/manageiq.py
@@ -9,28 +9,28 @@ DOCUMENTATION = '''
 module: manageiq
 short_description: Execute various operations in ManageIQ
 requirements: [ ManageIQ/manageiq-api-client-python ]
-author: Daniel Korn (dkorn)
+author: Daniel Korn (@dkorn)
 options:
   url:
     description:
       - the manageiq environment url
     required: true
-    default: []
+    default: null
   username:
     description:
       - manageiq username
     required: true
-    default: []
+    default: null
   password:
     description:
       - manageiq password
     required: true
-    default: []
+    default: null
   name:
     description:
       - the added provider name in manageiq
     required: true
-    default: []
+    default: null
   type:
     description:
       - the openshift provider type
@@ -40,17 +40,33 @@ options:
     description:
       - the added provider hostname
     required: true
-    default: []
+    default: null
   port:
     description:
       - the port used by the added provider
     required: true
-    default: []
+    default: null
   token:
     description:
       - the added provider token
     required: true
-    default: []
+    default: null
+  metrics:
+    description:
+      - whether metrics should be enabled in the provider
+    required: false
+    default: False
+    choices: ['True', 'False']
+  hawkular_hostname:
+    description:
+      - the hostname used for hawkular metrics
+    required: false
+    default: null
+  hawkular_port:
+    description:
+      - the port used for hawkular metrics
+    required: false
+    default: null
 '''
 
 EXAMPLES = '''
@@ -64,6 +80,9 @@ EXAMPLES = '''
     hostname: 'oshift01.redhat.com'
     port: '8443'
     token: '******'
+    metrics: True
+    hawkular_hostname: 'hawkular01.redhat.com'
+    hawkular_port: '443'
 '''
 
 
@@ -86,7 +105,7 @@ class ManageIQ(object):
         self.changed       = False
         self.providers_url = self.api_url + '/providers'
 
-    def update_required(self, provider_id, hostname, port):
+    def update_required(self, provider_id, endpoints):
         """ Checks whether an update is required for the provider
 
         Returns:
@@ -97,8 +116,12 @@ class ManageIQ(object):
             result = self.client.get(self.providers_url + '/%d/?attributes=authentications,endpoints' % provider_id)
         except Exception as e:
             self.module.fail_json(msg="Failed to get provider data. Error: %s" % e)
-        endpoint = result['endpoints'][0]
-        return False if (endpoint['hostname'] == hostname and endpoint['port'] == int(port)) else True
+
+        host_port = lambda endpoint: (endpoint['hostname'], int(endpoint['port']))
+
+        desired_by_role = {e['endpoint']['role']: host_port(e['endpoint']) for e in endpoints}
+        result_by_role = {e['role']: host_port(e) for e in result['endpoints']}
+        return desired_by_role != result_by_role
 
     def update_provider(self, provider_id, provider_name, endpoints):
         """ Updates the existing provider with new parameters
@@ -136,7 +159,29 @@ class ManageIQ(object):
         providers = self.client.collections.providers
         return next((p.id for p in providers if p.name == provider_name), None)
 
-    def add_or_update_provider(self, provider_name, provider_type, hostname, port, token):
+    def generate_endpoints(self, hostname, port, token, h_hostname, h_port):
+        """ Creates the provider endpoints
+
+        Returns:
+            the provider's endpoints, including the hawkular ones if metrics is required
+        """
+        endpoints = [{'endpoint': {'role': 'default', 'hostname': hostname,
+                                   'port': port},
+                      'authentication': {'role': 'bearer', 'auth_key': token}}]
+
+        # add hawkular endpoints if metrics is True
+        if self.module.params['metrics']:
+            if h_hostname is None or h_port is None:
+                self.module.fail_json(msg="hawkular hostname and port must be passed if metrics is True")
+            else:
+                endpoints.append({'endpoint': {'role': 'hawkular',
+                                               'hostname': h_hostname,
+                                               'port': h_port},
+                                  'authentication': {'role': 'hawkular',
+                                                     'auth_key': token}})
+        return endpoints
+
+    def add_or_update_provider(self, provider_name, provider_type, endpoints):
         """ Adds an OpenShift containers provider to manageiq or update it's
         attributes in case a provider with the same name already exists
 
@@ -144,16 +189,11 @@ class ManageIQ(object):
             the added or updated provider id, whether or not a change took place
             and a short message describing the operation executed
         """
-        endpoints = [{'endpoint': {'role': 'default', 'hostname': hostname,
-                                   'port': port},
-                     'authentication': {'role': 'bearer',
-                                        'auth_key': token}}]
         message = ""
-
         # check if provider with the same name already exists
         provider_id = self.find_provider_by_name(provider_name)
         if provider_id:  # provider exists
-            if self.update_required(provider_id, hostname, port):
+            if self.update_required(provider_id, endpoints):
                 self.update_provider(provider_id, provider_name, endpoints)
                 message = "Successfuly updated %s provider" % provider_name
             else:
@@ -179,10 +219,15 @@ def main():
             password=dict(required=True, no_log=True),
             port=dict(required=True),
             hostname=dict(required=True),
-            token=dict(required=True, no_log=True)
-        )
+            token=dict(required=True, no_log=True),
+            metrics=dict(required=False, type='bool', default=False),
+            hawkular_hostname=dict(required=False),
+            hawkular_port=dict(required=False)
+        ),
+        required_if=[
+            ('metrics', True, ['hawkular_hostname', 'hawkular_port']),
+        ],
     )
-
     url           = module.params['url']
     username      = module.params['username']
     password      = module.params['password']
@@ -191,10 +236,13 @@ def main():
     hostname      = module.params['hostname']
     port          = module.params['port']
     token         = module.params['token']
+    h_hostname    = module.params['hawkular_hostname']
+    h_port        = module.params['hawkular_port']
 
     manageiq = ManageIQ(module, url, username, password)
 
-    res_args = manageiq.add_or_update_provider(provider_name, provider_type, hostname, port, token)
+    endpoints = manageiq.generate_endpoints(hostname, port, token, h_hostname, h_port)
+    res_args = manageiq.add_or_update_provider(provider_name, provider_type, endpoints)
     module.exit_json(**res_args)
 
 


### PR DESCRIPTION
Adds the hawkular endpoints (endpoint and authentication). Also supports removing hawkular endpoints.

Need to specify:
- metrics: True (defualt is False)
- hawkular_hostname
- hawkular port

(the last two are required if metric is True)
