### PR TITLE
Fix Openshift provider type argument choices

### DIFF
--- a/library/manageiq.py
+++ b/library/manageiq.py
@@ -173,7 +173,7 @@ def main():
         argument_spec=dict(
             name=dict(required=True),
             type=dict(required=True,
-                      choices=['origin', 'enterprise']),
+                      choices=['openshift-origin', 'openshift-enterprise']),
             url=dict(required=True),
             username=dict(required=True),
             password=dict(required=True, no_log=True),


### PR DESCRIPTION
Following a change in the Openshift type strings,a change in the strings of the module arguments choices is also needed
