### PR TITLE
Add support for getting mangeiq url, username and password from the env vars by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,13 @@ ManageIQ Python API Client package [manageiq-api-client-python] (https://github.
 Currently, the module supports adding an OpenShift containers provider to manageiq.
 An example playbook `add_provider.yml` is provided and can be run by:
 
-    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin url=http://localhost:3000 hostname=oshift01.com port=8443 username=user password=****** token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin url=http://localhost:3000 username=user password=****** hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+
+Alternatively, it is possible to add the following environment variables, and remove them from the extra-vars string:
+
+    `$ export MIQ_URL=http://localhost:3000`
+    `$ export MIQ_USERNAME=admin`
+    `$ export MIQU_PASSWORD=******`
+
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
 

--- a/add_provider.yml
+++ b/add_provider.yml
@@ -6,9 +6,9 @@
     manageiq:
       name: '{{ name }}'
       type: '{{ type }}'
-      url: '{{ url }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
+      url: '{{ url | default(omit) }}'
+      username: '{{ username | default(omit) }}'
+      password: '{{ password | default(omit) }}'
       hostname: '{{ hostname }}'
       port: '{{ port }}'
       token: '{{ token }}'

--- a/library/manageiq.py
+++ b/library/manageiq.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import os
 from ansible.module_utils.basic import *
 from miqclient.api import API as MiqApi
 
@@ -14,18 +15,15 @@ options:
   url:
     description:
       - the manageiq environment url
-    required: true
-    default: null
+    default: MIQ_URL env var if set. otherwise, it is required to pass it
   username:
     description:
       - manageiq username
-    required: true
-    default: null
+    default: MIQ_USERNAME env var if set. otherwise, it is required to pass it
   password:
     description:
       - manageiq password
-    required: true
-    default: null
+    default: MIQ_PASSWORD env var if set. otherwise, it is required to pass it
   name:
     description:
       - the added provider name in manageiq
@@ -214,9 +212,9 @@ def main():
             name=dict(required=True),
             type=dict(required=True,
                       choices=['openshift-origin', 'openshift-enterprise']),
-            url=dict(required=True),
-            username=dict(required=True),
-            password=dict(required=True, no_log=True),
+            url=dict(default=os.environ.get('MIQ_URL', None)),
+            username=dict(default=os.environ.get('MIQ_USERNAME', None)),
+            password=dict(default=os.environ.get('MIQ_PASSWORD', None)),
             port=dict(required=True),
             hostname=dict(required=True),
             token=dict(required=True, no_log=True),
@@ -228,6 +226,11 @@ def main():
             ('metrics', True, ['hawkular_hostname', 'hawkular_port']),
         ],
     )
+
+    for arg in ['url', 'username', 'password']:
+        if module.params[arg] in (None, ''):
+            module.fail_json(msg="missing required argument: {}".format(arg))
+
     url           = module.params['url']
     username      = module.params['username']
     password      = module.params['password']


### PR DESCRIPTION
To use this option just add the vars to your env:
$ export MIQ_URL=http://localhost:3000
$ export MIQ_USERNAME=admin
$ export MIQU_PASSWORD=******

and remove them from the extra-vars string, when running the playbook
