### PR TITLE
Updating a Provider: report the updated values

### DIFF
--- a/tests/test_container_provider.py
+++ b/tests/test_container_provider.py
@@ -93,7 +93,14 @@ def test_will_update_provider_if_present(miq, endpoints, the_provider):
         "The provider", "openshift-origin", endpoints)
     assert res_args == {'changed': True,
                         'msg': 'Successfuly updated The provider provider',
-                        'provider_id': the_provider.id}
+                        'provider_id': the_provider.id,
+                        'updates': {
+                            'Added':
+                                {'hawkular': {
+                                    'hostname': 'The HHostname',
+                                    'port': 54321}},
+                            'Removed': {},
+                            'Updated': {}}}
 
 
 def test_reports_error(miq, endpoints, the_provider, miq_api_class):


### PR DESCRIPTION
Change `update_requiered` to return a hash of the values that need
updating and add that hash to the debug message.

```
ok: [localhost] => {
    "result": {
        "changed": true, 
        "msg": "Successfuly updated oshift01 provider. Changes: {'Removed': {u'hawkular': {'hostname': u'alon_gold.com', 'port': 1234}}, 'Updated': {'default': {'hostname': 'erez_oshift01.com'}}, 'Added': {}}", 
        "provider_id": 35
    }
}
```
