### PR TITLE
Delete provider functionality and 'state' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ManageIQ Python API Client package [manageiq-api-client-python] (https://github.
 Currently, the module supports adding an OpenShift containers provider to manageiq.
 An example playbook `add_provider.yml` is provided and can be run by:
 
-    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin url=http://localhost:3000 username=user password=****** hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present url=http://localhost:3000 username=user password=****** hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
 
 Alternatively, it is possible to add the following environment variables, and remove them from the extra-vars string:
 
@@ -26,4 +26,4 @@ Alternatively, it is possible to add the following environment variables, and re
     `$ export MIQ_USERNAME=admin`
     `$ export MIQ_PASSWORD=******`
 
-    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"

--- a/add_provider.yml
+++ b/add_provider.yml
@@ -9,6 +9,7 @@
       url: '{{ url | default(omit) }}'
       username: '{{ username | default(omit) }}'
       password: '{{ password | default(omit) }}'
+      state: '{{ state }}'
       hostname: '{{ hostname }}'
       port: '{{ port }}'
       token: '{{ token }}'


### PR DESCRIPTION
The 'state' option has two choices:
- 'present' - adds the provider if it does not exist or update the provider if the associated data is different
- 'absent' - deletes the provider if it exists

Delete action is done asynchronously as it could take a while to complete. Therefore, The delete task id is returned so it can be queried if needed.
