### PR TITLE
Add provider zone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ManageIQ Python API Client package [manageiq-api-client-python] (https://github.
 The `manageiq_provider` module currently supports adding, updating and deleting an OpenShift provider to manageiq.
 An example playbook `add_provider.yml` is provided and can be run by:
 
-    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present miq_url=http://localhost:3000 miq_username=user miq_password=****** hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present zone=default miq_url=http://localhost:3000 miq_username=user miq_password=****** hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
 
 Alternatively, it is possible to add the following environment variables, and remove them from the extra-vars string:
 
@@ -28,11 +28,10 @@ Alternatively, it is possible to add the following environment variables, and re
     `$ export MIQ_USERNAME=admin`
     `$ export MIQ_PASSWORD=******`
 
-    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present add_zone_option hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
 
 To update an existing provider pass the changed values together with the required parameters.
 
 To delete an OpenShift provider change `state=absent`.
 
 After addition or update, the authentication validation is verified for the provider.
-


### PR DESCRIPTION
It is possible to pass zone name for the added provider. The zone must already exist in manageiq.
If not passed, the 'default' zone will be chosen.
