### PR TITLE
Modules separation: rename module manageiq -> manageiq_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![travis image][]][travis status]
 
-This Ansible module provides different ManageIQ operations.
+Ansible modules which provide different ManageIQ operations.
 
 [travis image]: https://api.travis-ci.org/dkorn/manageiq-ansible-module.svg?branch=master
 [travis status]: https://travis-ci.org/dkorn/manageiq-ansible-module/branches
@@ -15,7 +15,9 @@ ManageIQ Python API Client package [manageiq-api-client-python] (https://github.
 
 ### Getting Started
 
-Currently, the module supports adding an OpenShift containers provider to manageiq.
+###### manageiq_provider module
+
+The `manageiq_provider` module currently supports adding, updating and deleting an OpenShift provider to manageiq.
 An example playbook `add_provider.yml` is provided and can be run by:
 
     `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present miq_url=http://localhost:3000 miq_username=user miq_password=****** hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
@@ -27,3 +29,10 @@ Alternatively, it is possible to add the following environment variables, and re
     `$ export MIQ_PASSWORD=******`
 
     `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present hostname=oshift01.com port=8443 token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+
+To update an existing provider pass the changed values together with the required parameters.
+
+To delete an OpenShift provider change `state=absent`.
+
+After addition or update, the authentication validation is verified for the provider.
+

--- a/add_provider.yml
+++ b/add_provider.yml
@@ -3,7 +3,7 @@
 
   tasks:
   - name: Add Openshift Containers Provider to ManageIQ
-    manageiq:
+    manageiq_provider:
       name: '{{ name }}'
       type: '{{ type }}'
       state: '{{ state }}'

--- a/library/manageiq_provider.py
+++ b/library/manageiq_provider.py
@@ -7,8 +7,8 @@ from miqclient.api import API as MiqApi
 
 DOCUMENTATION = '''
 ---
-module: manageiq
-short_description: Execute various operations in ManageIQ
+module: manageiq_provider
+short_description: add, update, delete provider in ManageIQ
 requirements: [ ManageIQ/manageiq-api-client-python ]
 author: Daniel Korn (@dkorn)
 options:
@@ -78,7 +78,7 @@ options:
 
 EXAMPLES = '''
 # Add Openshift Containers Provider to ManageIQ
-  manageiq:
+  manageiq_provider:
     name: 'Molecule'
     type: 'openshift-enterprise'
     state: 'present'

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     author_email='dkorn@redhat.com',
     url='https://github.com/dkorn/manageiq-ansible-module',
     package_dir={'': 'library'},
-    py_modules=["manageiq"],
+    py_modules=["manageiq_provider"],
     install_requires='ansible manageiq-api-client-python'.split(),
 )

--- a/tests/test_container_provider.py
+++ b/tests/test_container_provider.py
@@ -5,7 +5,7 @@ from mock import Mock
 from ansible.module_utils.basic import AnsibleModule
 
 from miqclient.api import API
-import manageiq
+import manageiq_provider
 
 
 PROVIDER_NAME = "Provider name 1 with some unicode characters «ταБЬℓσ»"
@@ -21,7 +21,7 @@ MANAGEIQ_HOSTNAME = "http://themanageiq.tld"
 @pytest.fixture(autouse=True)
 def miq_api_class(monkeypatch):
     miq_api_class = Mock(spec=API)
-    monkeypatch.setattr("manageiq.MiqApi", miq_api_class)
+    monkeypatch.setattr("manageiq_provider.MiqApi", miq_api_class)
     yield miq_api_class
 
 
@@ -58,8 +58,8 @@ def miq(miq_api_class, miq_ansible_module, the_provider):
         raise AnsibleModuleFailed(msg)
 
     miq_ansible_module.fail_json = fail
-    miq = manageiq.ManageIQ(miq_ansible_module, MANAGEIQ_HOSTNAME,
-                            "The username", "The password")
+    miq = manageiq_provider.ManageIQ(miq_ansible_module, MANAGEIQ_HOSTNAME,
+                                     "The username", "The password")
 
     miq_api_class.return_value.post.return_value = dict(results=[
         {'api_version': u'v1',


### PR DESCRIPTION
Needed changes in add_provider example playbook, setup and tests.
Also, updates for README.md.
