### PR TITLE
Rename type option to provider_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ManageIQ Python API Client package [manageiq-api-client-python] (https://github.
 The `manageiq_provider` module currently supports adding, updating and deleting an OpenShift provider to manageiq.
 An example playbook `add_provider.yml` is provided and can be run by:
 
-    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present zone=default miq_url=http://localhost:3000 miq_username=user miq_password=****** provider_api_hostname=oshift01.com provider_api_port=8443 provider_api_auth_token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 provider_type=openshift-origin state=present zone=default miq_url=http://localhost:3000 miq_username=user miq_password=****** provider_api_hostname=oshift01.com provider_api_port=8443 provider_api_auth_token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
 
 Alternatively, it is possible to add the following environment variables, and remove them from the extra-vars string:
 
@@ -28,7 +28,7 @@ Alternatively, it is possible to add the following environment variables, and re
     `$ export MIQ_USERNAME=admin`
     `$ export MIQ_PASSWORD=******`
 
-    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 type=openshift-origin state=present add_zone_option provider_api_hostname=oshift01.com provider_api_port=8443 provider_api_auth_token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
+    `$ ansible-playbook add_provider.yml --extra-vars "name=oshift01 provider_type=openshift-origin state=present add_zone_option provider_api_hostname=oshift01.com provider_api_port=8443 provider_api_auth_token=****** metrics=True hawkular_hostname=hawkular01.com hawkular_port=443"
 
 To update an existing provider pass the changed values together with the required parameters.
 

--- a/add_provider.yml
+++ b/add_provider.yml
@@ -5,7 +5,7 @@
   - name: Add Openshift Containers Provider to ManageIQ
     manageiq_provider:
       name: '{{ name }}'
-      type: '{{ type }}'
+      provider_type: '{{ provider_type }}'
       state: '{{ state }}'
       miq_url: '{{ miq_url | default(omit) }}'
       miq_username: '{{ miq_username | default(omit) }}'

--- a/tests/test_container_provider.py
+++ b/tests/test_container_provider.py
@@ -128,7 +128,7 @@ def test_will_add_provider_if_none_present(miq, endpoints):
 
 def test_will_update_provider_if_present(miq, endpoints, the_provider):
     res_args = miq.add_or_update_provider(
-        PROVIDER_NAME, "openshift-origin", endpoints, 'default')
+        PROVIDER_NAME, "openshift-origin", endpoints, "default")
     assert res_args == {
         'changed': True,
         'msg': 'Successfuly updated {} provider'.format(PROVIDER_NAME),
@@ -147,5 +147,5 @@ def test_reports_error(miq, endpoints, the_provider, miq_api_class):
     miq_api_class().get.side_effect = Exception("foo")
     with pytest.raises(AnsibleModuleFailed) as excinfo:
         miq.add_or_update_provider(
-            PROVIDER_NAME, "openshift-origin", endpoints, 'default')
+            PROVIDER_NAME, "openshift-origin", endpoints, "default")
     assert str(excinfo.value) == "Failed to get provider data. Error: foo"


### PR DESCRIPTION
The manager_type option specifies the supported provider class names.
This list of supported provider types is documented in the manageiq [REST API docs](http://manageiq.org/docs/reference/latest/api/reference/providers) 

