### PR TITLE
Add SSL Cert Verification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,9 @@ Alternatively, it is possible to add the following environment variables, and re
     `$ ansible-playbook assign_policy.yml --extra-vars "entity=policy entity_name=openscap resource=provider resource_name=openshift01 state=present"
 
 To unassign a policy/policy profile on a resource change `state=absent`.
+
+### SSL Cert Verification
+
+SSL verification for HTTPS requests is enabled by default.
+To use a self-signed certificate pass the certificate file or directory path using the ca_bundle_path option: `ca_bundle_path: '/path/to/certfile'`.
+To ignore verifying the SSL certificate pass `verify_ssl: False`

--- a/add_provider.yml
+++ b/add_provider.yml
@@ -16,6 +16,7 @@
       metrics: '{{ metrics | default(omit) }}'
       hawkular_hostname: '{{ hawkular_hostname | default(omit) }}'
       hawkular_port: '{{ hawkular_port | default(omit) }}'
+      verify_ssl: '{{ verify_ssl | default(True) }}'
     register: result
 
   - debug: var=result

--- a/tests/test_container_provider.py
+++ b/tests/test_container_provider.py
@@ -69,7 +69,8 @@ def miq(miq_api_class, miq_ansible_module, the_provider, the_zone):
 
     miq_ansible_module.fail_json = fail
     miq = manageiq_provider.ManageIQ(miq_ansible_module, MANAGEIQ_HOSTNAME,
-                                     "The username", "The password")
+                                     "The username", "The password",
+                                     verify_ssl=False, ca_bundle_path=None)
 
     miq_api_class.return_value.post.return_value = dict(results=[
         {'api_version': u'v1',


### PR DESCRIPTION
SSL certificate verification is enabled by default.
To use a self-signed certificate pass the certificate file or directory path using the ca_bundle_path option: `ca_bundle_path: '/path/to/certfile'`.

To ignore verifying the SSL certificate pass `verify_ssl: False`

depends on: https://github.com/ManageIQ/manageiq-api-client-python/pull/10
