### PR TITLE
Add examples of setting group triggers and members

### DIFF
--- a/examples/set_hawkular_group_triggers_and_member.yml
+++ b/examples/set_hawkular_group_triggers_and_member.yml
@@ -1,0 +1,51 @@
+---
+# Environment Variables
+#   This playbook assumes that the folliowing ManageIQ parameters are defined as environment variables:
+#   miq_url (MIQ_URL), miq_username (MIQ_USERNAME), miq_password (MIQ_PASSWORD)
+
+- hosts: localhost
+  vars_files:
+  - vars.yml
+  tasks:
+
+  - name: Create group trigger in Hawkular Alerts
+    with_subelements:
+      - "{{ hawkular_providers }}"
+      - triggers
+    hawkular_alerts_group_trigger:
+      hawkular_api_hostname: "{{ item.0.hostname }}"
+      hawkular_api_port: "{{ item.0.port }}"
+      hawkular_api_auth_token: "{{ item.0.token }}"
+      tenant:  "{{ item.0.tenant }}"
+      group_id: "{{ item.1.id }}"
+      name: "{{ item.1.name }}"
+      event_text: "{{ item.1.event_text|default() }}"
+      severity: "{{ item.1.severity}}"
+      auto_resolve: "{{ item.1.auto_resolve|default() }}"
+      tags: "{{ item.1.tags|default({}) }}"
+      conditions: "{{ item.1.conditions }}"
+      state: 'present'
+      verify_ssl: False
+    register: result
+
+  - debug: var=result
+
+  - name: Create group members in Hawkular Alerts
+    with_items:
+       - "{{ group_trigger_members }}"
+    hawkular_alerts_group_member:
+      hawkular_api_hostname: "{{ item.hostname }}"
+      hawkular_api_port: "{{ item.port }}"
+      hawkular_api_auth_token: "{{ item.token }}"
+      tenant:  "{{ item.tenant }}"
+      group_id: "{{ item.group_id }}"
+      id: "{{ item.id }}"
+      name:  "{{ item.name }}"
+      description:  "{{ item.description|default() }}"
+      data_id_map: "{{ item.data_id_map }}"
+      tags: "{{ item.tags|default({}) }}"
+      state: 'present'
+      verify_ssl: False
+    register: result
+
+  - debug: var=result

--- a/examples/set_hawkular_group_triggers_and_member.yml
+++ b/examples/set_hawkular_group_triggers_and_member.yml
@@ -5,7 +5,7 @@
 
 - hosts: localhost
   vars_files:
-  - vars.yml
+  - vars_heapster.yml
   tasks:
 
   - name: Create group trigger in Hawkular Alerts
@@ -24,7 +24,7 @@
       auto_resolve: "{{ item.1.auto_resolve|default() }}"
       tags: "{{ item.1.tags|default({}) }}"
       conditions: "{{ item.1.conditions }}"
-      state: 'present'
+      state: "{{state | default('present')}}"
       verify_ssl: False
     register: result
 
@@ -44,7 +44,7 @@
       description:  "{{ item.description|default() }}"
       data_id_map: "{{ item.data_id_map }}"
       tags: "{{ item.tags|default({}) }}"
-      state: 'present'
+      state: "{{state | default('present')}}"
       verify_ssl: False
     register: result
 

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -1,0 +1,113 @@
+---
+hawkular_providers:
+  - name: hawkular01
+    type: hawkular-datawarehouse
+    hostname: hawkular-metrics.url.com
+    port: 443
+    token: secret
+    tenant: _ops
+    triggers:
+    - id: test-docker-ping
+      name: Test Docker Ping
+      severity: HIGH
+      auto_resolve: true
+      tags:
+        type: node
+        url: https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_docker_ping.asciidoc
+      conditions:
+        - name: Docker Ping Error
+          trigger_mode: FIRING
+          type: THRESHOLD
+          data_id: docker.ping
+          operator: LT
+          threshold: 1
+        - name: Docker Ping Ok
+          trigger_mode: AUTORESOLVE
+          type: THRESHOLD
+          data_id: docker.ping
+          operator: GTE
+          threshold: 1
+    - id: test-cpu-idle
+      name: Test CPU Idle
+      event_text: CPU IDLE is less than 5%
+      severity: MEDIUM
+      auto_resolve: true
+      tags:
+        type: node
+        url: https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_cpu_idle.asciidoc
+      conditions:
+        - name: CPU IDLE Too low
+          trigger_mode: FIRING
+          type: THRESHOLD
+          data_id: kernel.all.cpu.idle
+          operator: LT
+          threshold: 5
+        - name: CPU IDLE Ok
+          trigger_mode: AUTORESOLVE
+          type: THRESHOLD
+          data_id: kernel.all.cpu.idle
+          operator: GTE
+          threshold: 5
+    - id: test-openshift-node-process-count
+      name: Test Openshift Node process count
+      severity: HIGH
+      auto_resolve: true
+      tags:
+        type: node
+        url: https://github.com/openshift/ops-sop/blob/node/V3/Alerts/openshift_node.asciidoc
+      conditions:
+        - name: Process count Not 1
+          trigger_mode: FIRING
+          type: RANGE
+          data_id: openshift.node.process.count
+          operator_low: INCLUSIVE
+          threshold_low: 1
+          operator_high: INCLUSIVE
+          threshold_high: 1
+          in_range: false
+        - name: Process count is 1
+          trigger_mode: AUTORESOLVE
+          type: RANGE
+          data_id: openshift.node.process.count
+          operator_low: INCLUSIVE
+          threshold_low: 1
+          operator_high: INCLUSIVE
+          threshold_high: 1
+          in_range: true
+group_trigger_members:
+  - name: Docker Ping Member
+    description: docker.ping failed on example.node.com
+    hostname: hawkular-metrics.url.com
+    id: master-node-member-docker-ping
+    port: 443
+    token: secret
+    tenant: _ops
+    group_id: test-docker-ping
+    data_id_map:
+       docker.ping: hm_g_node/example.node.com/docker.ping
+    tags:
+       nodename: example.node.com
+  - name: Idle CPU Member
+    description: CPU idle less than 5% on example.node.com
+    hostname: hawkular-metrics.url.com
+    id: master-node-member-idle-cpu
+    port: 443
+    token: secret
+    tenant: _ops
+    group_id: test-cpu-idle
+    data_id_map:
+       kernel.all.cpu.idle: hm_g_node/example.node.com/kernel.all.cpu.idle
+    tags:
+       nodename: example.node.com
+  - name: Node process count Member
+    description: Openshift Node process not running on example.node.com
+    hostname: hawkular-metrics.url.com
+    id: master-node-member-node-process-count
+    port: 443
+    token: secret
+    tenant: _ops
+    group_id: test-openshift-node-process-count
+    data_id_map:
+       openshift.node.process.count: hm_g_node/example.node.com/openshift.node.process.count
+    tags:
+       nodename: example.node.com

--- a/examples/vars_heapster.yml
+++ b/examples/vars_heapster.yml
@@ -1,0 +1,78 @@
+---
+
+hawkular_host: yzamir-centos7-4.eng.lab.tlv.redhat.com
+hawkular_token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtYW5hZ2VtZW50LWluZnJhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im1hbmFnZW1lbnQtYWRtaW4tdG9rZW4tM3Jyem4iLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibWFuYWdlbWVudC1hZG1pbiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6ImZhN2UzYjJhLTNhMWEtMTFlNy1hZjBlLTAwMWE0YTIzMTRkOCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptYW5hZ2VtZW50LWluZnJhOm1hbmFnZW1lbnQtYWRtaW4ifQ.YGFnSjFdUYc2DiKSUEs6ybVexHwJ6LU7YcWoWler8iEqU19UFLC2ASMkAZ9BL6RplZX0X2ISma1NXTJciPbweDtn4AX6BVCFyPqeAUacG-wxdeHfAqAMrr-s1LJqNSAwsfE0ODgewEyj9Q8n1fgIOUGTmvDx6Sl4G5sgoyOZSbwGyc7qeMRfp9EUV729G2vXl_UcMVwIuUdaaDpVXPW9OgzF3Q3thhXDXWH6B-z3XhLAO4estKHQs5FH4ZR1G9e4AJ0K5oPKTmOT2gmTQkaAYNUW_GQdeleHKle4ix8-HouCgo0LegL2io3DIIbVI4qMr7ae-ATCSrtQAKLv0_aN4Q
+hawkular_tenant: _system
+hawkular_node: vm-48-39.eng.lab.tlv.redhat.com
+
+hawkular_providers:
+  - name: hawkular01
+    type: hawkular-datawarehouse
+    hostname: "{{ hawkular_host }}"
+    port: 443
+    token: "{{ hawkular_token }}"
+    tenant: "{{ hawkular_tenant }}"
+    triggers:
+    - id: test-cpu-node-utilization
+      name: Test CPU node utilization
+      event_text: CPU node utilization more than 90%
+      severity: MEDIUM
+      auto_resolve: true
+      tags:
+        type: node
+      conditions:
+        - name: CPU node utilization too high
+          trigger_mode: FIRING
+          type: THRESHOLD
+          data_id: cpu.node_utilization
+          operator: GT
+          threshold: 0.40
+        - name: CPU Utilization Ok
+          trigger_mode: AUTORESOLVE
+          type: THRESHOLD
+          data_id: cpu.node_utilization
+          operator: LTE
+          threshold: 0.40
+#    - id: test-memory-node-utilization
+#      name: Test memory node utilization
+#      severity: HIGH
+#      auto_resolve: true
+#      tags:
+#        type: node
+#      conditions:
+#        - name: Memory node utilization too high
+#          type: THRESHOLD
+#          data_id: memory.node_utilization
+#          operator: GT
+#          threshold: 0.80
+#        - name: Memory Usage Ok
+#          trigger_mode: AUTORESOLVE
+#          type: THRESHOLD
+#          data_id: memory.node_utilization
+#          operator: LTE
+#          threshold: 0.80
+group_trigger_members:
+  - name: CPU node_utilization Member
+    description: CPU node_utilization more than 90% on {{ hawkular_node }}
+    hostname: "{{ hawkular_host }}"
+    id: member-cpu-usage
+    port: 443
+    token: "{{ hawkular_token }}"
+    tenant: "{{ hawkular_tenant }}"
+    group_id: test-cpu-node-utilization
+    data_id_map:
+       cpu.node_utilization: hm_g_machine/{{ hawkular_node }}/cpu/usage
+    tags:
+       nodename: "{{ hawkular_node }}"
+#  - name: Memory Usage member
+#    description: CPU usage less than 5% on {{ hawkular_node }}
+#    hostname: "{{ hawkular_host }}"
+#    id: member-memory-usage
+#    port: 443
+#    token: "{{ hawkular_token }}"
+#    tenant: "{{ hawkular_tenant }}"
+#    group_id: test-memory-node-utilization
+#    data_id_map:
+#       memory.node_utilization: hm_g_machine/{{ hawkular_node }}/memory/usage
+#    tags:
+#       nodename: "{{ hawkular_node }}"


### PR DESCRIPTION
Examples that set autoresolving triggers for ops metrics:
       docker.ping < 1
       kernel.all.cpu.idle < 5
       openshift.node.process.count != 1
