### PR TITLE
Support for provider TLS and custom CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ To try the modules copy and edit the relevant example playbook and execute:
 The `manageiq_provider` module currently supports adding, updating and deleting OpenShift, Amazon EC2 and Hawkular Datawarehouse providers to manageiq.  
 Example playbooks [add_openshift_provider.yml](add_openshift_provider.yml), [add_amazon_provider.yml](add_amazon_provider.yml) and [add_hawkular_datawarehouse_provider.yml](add_hawkular_datawarehouse_provider.yml) are provided.
 To update an existing provider pass the changed values together with the required parameters. To delete a provider change `state=absent`.  
+SSL verification for HTTPS requests between ManageIQ and the provider is enabled by default. To ignore pass `provider_verify_ssl: false`.
+To use a self-signed certificate pass: `provider_ca_path: '/path/to/certfile'`.  
 After addition or update, each endpoint authentication is validated, a process which can take up to 50 seconds before timeout.
 If all authentications are valid the provider's inventory is refreshed.
 

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ It is possible to set the following environment variables, and remove them from 
 SSL verification for HTTPS requests is enabled by default.
 
 To use a self-signed certificate pass the certificate file or directory path using the ca_bundle_path option: `ca_bundle_path: '/path/to/certfile'`.
-To ignore verifying the SSL certificate pass `verify_ssl: False`
+To ignore verifying the SSL certificate pass `miq_verify_ssl: False`

--- a/add_amazon_provider.yml
+++ b/add_amazon_provider.yml
@@ -13,7 +13,7 @@
       miq_url: 'http://miq.example.com'
       miq_username: 'admin'
       miq_password: '******'
-      verify_ssl: False
+      miq_verify_ssl: false
     register: result
 
   - debug: var=result

--- a/add_custom_attributes.yml
+++ b/add_custom_attributes.yml
@@ -15,7 +15,7 @@
       miq_url: 'https://miq.example.com'
       miq_username: 'dkorn'
       miq_password: '******'
-      verify_ssl: False
+      miq_verify_ssl: false
     register: result
 
   - debug: var=result

--- a/add_hawkular_datawarehouse_provider.yml
+++ b/add_hawkular_datawarehouse_provider.yml
@@ -13,7 +13,7 @@
       miq_url: 'http://miq.example.com'
       miq_username: 'admin'
       miq_password: '******'
-      verify_ssl: false
+      miq_verify_ssl: false
       provider_verify_ssl: false
     register: result
 

--- a/add_hawkular_datawarehouse_provider.yml
+++ b/add_hawkular_datawarehouse_provider.yml
@@ -13,7 +13,8 @@
       miq_url: 'http://miq.example.com'
       miq_username: 'admin'
       miq_password: '******'
-      verify_ssl: False
+      verify_ssl: false
+      provider_verify_ssl: false
     register: result
 
   - debug: var=result

--- a/add_openshift_provider.yml
+++ b/add_openshift_provider.yml
@@ -16,8 +16,8 @@
       miq_url: 'http://miq.example.com'
       miq_username: 'admin'
       miq_password: '******'
-      verify_ssl: false
-      provider_verify_ssl
+      miq_verify_ssl: false
+      provider_verify_ssl: false
     register: result
 
   - debug: var=result

--- a/add_openshift_provider.yml
+++ b/add_openshift_provider.yml
@@ -16,7 +16,8 @@
       miq_url: 'http://miq.example.com'
       miq_username: 'admin'
       miq_password: '******'
-      verify_ssl: False
+      verify_ssl: false
+      provider_verify_ssl
     register: result
 
   - debug: var=result

--- a/assign_policy.yml
+++ b/assign_policy.yml
@@ -12,7 +12,7 @@
       miq_url: 'http://miq.example.com'
       miq_username: 'admin'
       miq_password: '******'
-      verify_ssl: False
+      miq_verify_ssl: false
     register: result
 
   - debug: var=result

--- a/create_user.yml
+++ b/create_user.yml
@@ -12,7 +12,7 @@
       miq_url: 'http://miq.example.com'
       miq_username: 'admin'
       miq_password: '******'
-      verify_ssl: False
+      miq_verify_ssl: False
     register: result
 
   - debug: var=result

--- a/library/manageiq_custom_attributes.py
+++ b/library/manageiq_custom_attributes.py
@@ -49,7 +49,7 @@ options:
       - the custom attributes of the entity
     required: true
     default: null
-  verify_ssl:
+  miq_verify_ssl:
     description:
       - whether SSL certificates should be verified for HTTPS requests
     required: false
@@ -86,18 +86,18 @@ class ManageIQCustomAttributes(object):
     url            - manageiq environment url
     user           - the username in manageiq
     password       - the user password in manageiq
-    verify_ssl     - whether SSL certificates should be verified for HTTPS requests
+    miq_verify_ssl - whether SSL certificates should be verified for HTTPS requests
     ca_bundle_path - the path to a CA_BUNDLE file or directory with certificates
     """
 
     supported_entities = {'vm': 'vms', 'provider': 'providers'}
 
-    def __init__(self, module, url, user, password, verify_ssl, ca_bundle_path):
+    def __init__(self, module, url, user, password, miq_verify_ssl, ca_bundle_path):
         self.module        = module
         self.api_url       = url + '/api'
         self.user          = user
         self.password      = password
-        self.client        = MiqApi(self.api_url, (self.user, self.password), verify_ssl=verify_ssl, ca_bundle_path=ca_bundle_path)
+        self.client        = MiqApi(self.api_url, (self.user, self.password), verify_ssl=miq_verify_ssl, ca_bundle_path=ca_bundle_path)
         self.changed       = False
 
     def find_entity_by_name(self, entity_type, entity_name):
@@ -242,7 +242,7 @@ def main():
             miq_url=dict(default=os.environ.get('MIQ_URL', None)),
             miq_username=dict(default=os.environ.get('MIQ_USERNAME', None)),
             miq_password=dict(default=os.environ.get('MIQ_PASSWORD', None), no_log=True),
-            verify_ssl=dict(require=False, type='bool', default=True),
+            miq_verify_ssl=dict(require=False, type='bool', default=True),
             ca_bundle_path=dict(required=False, type='str', defualt=None),
         )
     )
@@ -258,14 +258,14 @@ def main():
     entity_type       = module.params['entity_type']
     state             = module.params['state']
     custom_attributes = module.params['custom_attributes']
-    verify_ssl        = module.params['verify_ssl']
+    miq_verify_ssl    = module.params['miq_verify_ssl']
     ca_bundle_path    = module.params['ca_bundle_path']
 
     for ca in custom_attributes:
         if 'section' not in ca:
             ca['section'] = 'metadata'
 
-    manageiq = ManageIQCustomAttributes(module, miq_url, miq_username, miq_password, verify_ssl, ca_bundle_path)
+    manageiq = ManageIQCustomAttributes(module, miq_url, miq_username, miq_password, miq_verify_ssl, ca_bundle_path)
     if state == 'present':
         res_args = manageiq.add_or_update_custom_attributes(entity_type, entity_name,
                                                             custom_attributes)

--- a/library/manageiq_policy_assignment.py
+++ b/library/manageiq_policy_assignment.py
@@ -52,7 +52,7 @@ options:
     required: false
     choices: ['present', 'absent']
     default: 'present'
-  verify_ssl:
+  miq_verify_ssl:
     description:
       - whether SSL certificates should be verified for HTTPS requests
     required: false
@@ -82,10 +82,10 @@ EXAMPLES = '''
 class ManageIQ(object):
     """ ManageIQ object to execute policy assignments in manageiq
 
-    url      - manageiq environment url
-    user     - the username in manageiq
-    password - the user password in manageiq
-    verify_ssl     - whether SSL certificates should be verified for HTTPS requests
+    url            - manageiq environment url
+    user           - the username in manageiq
+    password       - the user password in manageiq
+    miq_verify_ssl - whether SSL certificates should be verified for HTTPS requests
     ca_bundle_path - the path to a CA_BUNDLE file or directory with certificates
     """
 
@@ -100,12 +100,12 @@ class ManageIQ(object):
         'present': 'assign', 'absent': 'unassign'
     }
 
-    def __init__(self, module, url, user, password, verify_ssl, ca_bundle_path):
+    def __init__(self, module, url, user, password, miq_verify_ssl, ca_bundle_path):
         self.module        = module
         self.api_url       = url + '/api'
         self.user          = user
         self.password      = password
-        self.client        = MiqApi(self.api_url, (self.user, self.password), verify_ssl=verify_ssl, ca_bundle_path=ca_bundle_path)
+        self.client        = MiqApi(self.api_url, (self.user, self.password), verify_ssl=miq_verify_ssl, ca_bundle_path=ca_bundle_path)
         self.changed       = False
 
     def find_entity_by_name(self, entity_type, entity_name):
@@ -201,7 +201,7 @@ def main():
             miq_url=dict(default=os.environ.get('MIQ_URL', None)),
             miq_username=dict(default=os.environ.get('MIQ_USERNAME', None)),
             miq_password=dict(default=os.environ.get('MIQ_PASSWORD', None), no_log=True),
-            verify_ssl=dict(require=False, type='bool', default=True),
+            miq_verify_ssl=dict(require=False, type='bool', default=True),
             ca_bundle_path=dict(required=False, type='str', defualt=None),
         )
     )
@@ -218,10 +218,10 @@ def main():
     resource       = module.params['resource']
     resource_name  = module.params['resource_name']
     state          = module.params['state']
-    verify_ssl     = module.params['verify_ssl']
+    miq_verify_ssl = module.params['miq_verify_ssl']
     ca_bundle_path = module.params['ca_bundle_path']
 
-    manageiq = ManageIQ(module, miq_url, miq_username, miq_password, verify_ssl, ca_bundle_path)
+    manageiq = ManageIQ(module, miq_url, miq_username, miq_password, miq_verify_ssl, ca_bundle_path)
     res_args = manageiq.assign_or_unassign_entity(entity, entity_name, resource, resource_name, state)
 
     module.exit_json(**res_args)

--- a/library/manageiq_provider.py
+++ b/library/manageiq_provider.py
@@ -25,7 +25,7 @@ options:
     description:
       - manageiq password
     default: MIQ_PASSWORD env var if set. otherwise, it is required to pass it
-  verify_ssl:
+  miq_verify_ssl:
     description:
       - whether SSL certificates should be verified for HTTPS requests to ManageIQ
     required: false
@@ -118,7 +118,7 @@ EXAMPLES = '''
     provider_api_hostname: 'oshift01.redhat.com'
     provider_api_port: '8443'
     provider_api_auth_token: '******'
-    verify_ssl: false
+    miq_verify_ssl: false
     provider_verify_ssl: false
     metrics: True
     hawkular_hostname: 'hawkular01.redhat.com'
@@ -132,7 +132,7 @@ EXAMPLES = '''
     miq_url: 'https://miq.example.com'
     miq_username: 'admin'
     miq_password: '******'
-    verify_ssl: true
+    miq_verify_ssl: true
     ca_bundle_path: '/path/to/certfile'
     provider_verify_ssl: true
     provider_ca_path: '/path/to/provider/certfile'
@@ -148,7 +148,7 @@ EXAMPLES = '''
     access_key_id: '******'
     secret_access_key: '******'
     state: 'present'
-    verify_ssl: false
+    miq_verify_ssl: false
     miq_url: 'http://localhost:3000'
     miq_username: 'admin'
     miq_password: '******'
@@ -164,7 +164,7 @@ EXAMPLES = '''
     miq_url: 'http://miq.example.com'
     miq_username: 'admin'
     miq_password: '******'
-    verify_ssl: false
+    miq_verify_ssl: false
 '''
 
 
@@ -174,7 +174,7 @@ class ManageIQ(object):
     url            - manageiq environment url
     user           - the username in manageiq
     password       - the user password in manageiq
-    verify_ssl     - whether SSL certificates should be verified for HTTPS requests
+    miq_verify_ssl - whether SSL certificates should be verified for HTTPS requests
     ca_bundle_path - the path to a CA_BUNDLE file or directory with certificates
     """
 
@@ -190,12 +190,12 @@ class ManageIQ(object):
     WAIT_TIME = 5
     ITERATIONS = 10
 
-    def __init__(self, module, url, user, password, verify_ssl, ca_bundle_path):
+    def __init__(self, module, url, user, password, miq_verify_ssl, ca_bundle_path):
         self.module        = module
         self.api_url       = url + '/api'
         self.user          = user
         self.password      = password
-        self.client        = MiqApi(self.api_url, (self.user, self.password), verify_ssl=verify_ssl, ca_bundle_path=ca_bundle_path)
+        self.client        = MiqApi(self.api_url, (self.user, self.password), verify_ssl=miq_verify_ssl, ca_bundle_path=ca_bundle_path)
         self.changed       = False
         self.providers_url = self.api_url + '/providers'
 
@@ -460,7 +460,7 @@ def main():
                                    required=False),
             provider_api_hostname=dict(required=False),
             provider_api_auth_token=dict(required=False, no_log=True),
-            verify_ssl=dict(require=False, type='bool', default=True),
+            miq_verify_ssl=dict(require=False, type='bool', default=True),
             ca_bundle_path=dict(required=False, type='str', defualt=None),
             provider_verify_ssl=dict(require=False, type='bool', default=True),
             provider_ca_path=dict(required=False, type='str', defualt=None),
@@ -487,7 +487,7 @@ def main():
     miq_url             = module.params['miq_url']
     miq_username        = module.params['miq_username']
     miq_password        = module.params['miq_password']
-    verify_ssl          = module.params['verify_ssl']
+    miq_verify_ssl      = module.params['miq_verify_ssl']
     ca_bundle_path      = module.params['ca_bundle_path']
     provider_verify_ssl = module.params['provider_verify_ssl']
     provider_ca_path    = module.params['provider_ca_path']
@@ -504,7 +504,7 @@ def main():
     h_hostname          = module.params['hawkular_hostname']
     h_port              = module.params['hawkular_port']
 
-    manageiq = ManageIQ(module, miq_url, miq_username, miq_password, verify_ssl, ca_bundle_path)
+    manageiq = ManageIQ(module, miq_url, miq_username, miq_password, miq_verify_ssl, ca_bundle_path)
 
     if state == 'present':
         if provider_type in ("openshift-enterprise", "openshift-origin"):

--- a/library/manageiq_user.py
+++ b/library/manageiq_user.py
@@ -53,7 +53,7 @@ options:
       - On absent, it will delete the user if it exists
     required: false
     choices: ['present', 'absent']
-  verify_ssl:
+  miq_verify_ssl:
     description:
       - whether SSL certificates should be verified for HTTPS requests
     required: false
@@ -78,7 +78,7 @@ EXAMPLES = '''
     miq_url: 'http://localhost:3000'
     miq_username: 'admin'
     miq_password: '******'
-    verify_ssl: False
+    miq_verify_ssl: False
 '''
 
 import os
@@ -91,16 +91,16 @@ class ManageIQUser(object):
     url            - manageiq environment url
     user           - the username in manageiq
     password       - the user password in manageiq
-    verify_ssl     - whether SSL certificates should be verified for HTTPS requests
+    miq_verify_ssl - whether SSL certificates should be verified for HTTPS requests
     ca_bundle_path - the path to a CA_BUNDLE file or directory with certificates
     """
 
-    def __init__(self, module, url, user, password, verify_ssl, ca_bundle_path):
+    def __init__(self, module, url, user, password, miq_verify_ssl, ca_bundle_path):
         self.module        = module
         self.api_url       = url + '/api'
         self.user          = user
         self.password      = password
-        self.client        = MiqApi(self.api_url, (self.user, self.password), verify_ssl=verify_ssl, ca_bundle_path=ca_bundle_path)
+        self.client        = MiqApi(self.api_url, (self.user, self.password), verify_ssl=miq_verify_ssl, ca_bundle_path=ca_bundle_path)
         self.changed       = False
 
     def find_group_by_name(self, group_name):
@@ -225,7 +225,7 @@ def main():
             miq_url=dict(default=os.environ.get('MIQ_URL', None)),
             miq_username=dict(default=os.environ.get('MIQ_USERNAME', None)),
             miq_password=dict(default=os.environ.get('MIQ_PASSWORD', None), no_log=True),
-            verify_ssl=dict(require=False, type='bool', default=True),
+            miq_verify_ssl=dict(require=False, type='bool', default=True),
             ca_bundle_path=dict(required=False, type='str', defualt=None)
         ),
         required_if=[
@@ -240,7 +240,7 @@ def main():
     miq_url        = module.params['miq_url']
     miq_username   = module.params['miq_username']
     miq_password   = module.params['miq_password']
-    verify_ssl     = module.params['verify_ssl']
+    miq_verify_ssl = module.params['miq_verify_ssl']
     ca_bundle_path = module.params['ca_bundle_path']
     name           = module.params['name']
     fullname       = module.params['fullname']
@@ -249,7 +249,7 @@ def main():
     email          = module.params['email']
     state          = module.params['state']
 
-    manageiq = ManageIQUser(module, miq_url, miq_username, miq_password, verify_ssl, ca_bundle_path)
+    manageiq = ManageIQUser(module, miq_url, miq_username, miq_password, miq_verify_ssl, ca_bundle_path)
     if state == "present":
         res_args = manageiq.create_or_update_user(name, fullname, password,
                                                   group, email)

--- a/tests/test_custom_attributes.py
+++ b/tests/test_custom_attributes.py
@@ -108,7 +108,7 @@ def miq(miq_api_class, miq_ansible_module, the_provider):
     miq_ansible_module.fail_json = fail
     miq = manageiq_custom_attributes.ManageIQCustomAttributes(
         miq_ansible_module, MANAGEIQ_HOSTNAME, "The username", "The password",
-        verify_ssl=False, ca_bundle_path=None)
+        miq_verify_ssl=False, ca_bundle_path=None)
 
     miq_api_class.return_value.collections.providers = [the_provider]
 

--- a/tests/test_manageiq_policy_assignment.py
+++ b/tests/test_manageiq_policy_assignment.py
@@ -56,7 +56,7 @@ def miq(miq_api_class, miq_ansible_module, the_policy_profile, the_provider):
     miq_ansible_module.fail_json = fail
     miq = manageiq_policy_assignment.ManageIQ(
             miq_ansible_module, MANAGEIQ_HOSTNAME, "The username",
-            "The password", verify_ssl=False, ca_bundle_path=None)
+            "The password", miq_verify_ssl=False, ca_bundle_path=None)
 
     miq_api_class.return_value.post.return_value = dict(results=[
         {"success": True,

--- a/tests/test_manageiq_provider.py
+++ b/tests/test_manageiq_provider.py
@@ -233,7 +233,7 @@ def miq(miq_api_class, miq_ansible_module, the_provider, the_amazon_provider, th
     miq_ansible_module.fail_json = fail
     miq = manageiq_provider.ManageIQ(miq_ansible_module, MANAGEIQ_HOSTNAME,
                                      "The username", "The password",
-                                     verify_ssl=False, ca_bundle_path=None)
+                                     miq_verify_ssl=False, ca_bundle_path=None)
 
     miq_api_class.return_value.collections.zones = [the_zone]
 

--- a/tests/test_manageiq_provider.py
+++ b/tests/test_manageiq_provider.py
@@ -14,6 +14,8 @@ HAWK_DW_PROVIDER_NAME = "hawkular datawarehouse provider"
 PROVIDER_HOSTNAME = "some-provider-hostname.tld"
 PROVIDER_TOKEN = "THE_PROVIDER_TOKEN"
 PROVIDER_PORT = 8443
+PROVIDER_VERIFY_SSL = False
+PROVIDER_CA_PATH = ""
 AMAZON_USERID = "THE_PROVIDER_USERID"
 AMAZON_PASSWORD = "THE_PROVIDER_PASSWORD"
 AMAZON_PROVIDER_REGION = "THE_PROVIDER-REGION"
@@ -189,14 +191,16 @@ def miq_ansible_module():
 def openshift_endpoint(miq):
     yield [
         miq.generate_auth_key_config("default", "bearer", PROVIDER_HOSTNAME,
-                                     PROVIDER_PORT, PROVIDER_TOKEN)]
+                                     PROVIDER_PORT, PROVIDER_TOKEN,
+                                     PROVIDER_VERIFY_SSL, PROVIDER_CA_PATH)]
 
 
 @pytest.fixture
 def hawkular_endpoint(miq):
     yield [
         miq.generate_auth_key_config("hawkular", "hawkular", HAWKULAR_HOSTNAME,
-                                     HAWKULAR_PORT, PROVIDER_TOKEN)]
+                                     HAWKULAR_PORT, PROVIDER_TOKEN,
+                                     PROVIDER_VERIFY_SSL, PROVIDER_CA_PATH)]
 
 
 @pytest.fixture
@@ -210,7 +214,8 @@ def amazon_endpoint(miq):
 def hawk_dw_endpoint(miq):
     yield [
         miq.generate_auth_key_config("default", "default", HAWK_DW_HOSTNAME,
-                                     HAWK_DW_PROVIDER_PORT, HAWK_DW_PROVIDER_TOKEN)]
+                                     HAWK_DW_PROVIDER_PORT, HAWK_DW_PROVIDER_TOKEN,
+                                     PROVIDER_VERIFY_SSL, PROVIDER_CA_PATH)]
 
 
 
@@ -239,12 +244,16 @@ def test_generate_auth_key_config(miq):
     endpoint = miq.generate_auth_key_config("default", "bearer",
                                             PROVIDER_HOSTNAME,
                                             PROVIDER_PORT,
-                                            PROVIDER_TOKEN)
+                                            PROVIDER_TOKEN,
+                                            PROVIDER_VERIFY_SSL,
+                                            PROVIDER_CA_PATH)
     assert endpoint == {'authentication': {'auth_key': PROVIDER_TOKEN,
                                            'authtype': 'bearer'},
                         'endpoint': {'hostname': PROVIDER_HOSTNAME,
                                      'port': PROVIDER_PORT,
-                                     'role': 'default'}}
+                                     'role': 'default',
+                                     'certificate_authority': None,
+                                     'verify_ssl': PROVIDER_VERIFY_SSL}}
 
 
 def test_will_add_openshift_provider_if_none_present(miq, miq_api_class, openshift_endpoint):
@@ -264,7 +273,9 @@ def test_will_add_openshift_provider_if_none_present(miq, miq_api_class, openshi
                   connection_configurations=[
                       {'endpoint': {'port': PROVIDER_PORT,
                                     'role': 'default',
-                                    'hostname': PROVIDER_HOSTNAME},
+                                    'hostname': PROVIDER_HOSTNAME,
+                                    'verify_ssl': PROVIDER_VERIFY_SSL,
+                                    'certificate_authority': None},
                        'authentication': {'auth_key': PROVIDER_TOKEN,
                                           'authtype': 'bearer'}}],
                   name=PROVIDER_NAME,
@@ -322,7 +333,9 @@ def test_will_add_hawkular_datawarehose_provider_if_none_present(miq, miq_api_cl
                   connection_configurations=[
                       {'endpoint': {'port': HAWK_DW_PROVIDER_PORT,
                                     'role': 'default',
-                                    'hostname': HAWK_DW_HOSTNAME},
+                                    'hostname': HAWK_DW_HOSTNAME,
+                                    'verify_ssl': PROVIDER_VERIFY_SSL,
+                                    'certificate_authority': None},
                        'authentication': {'auth_key': HAWK_DW_PROVIDER_TOKEN,
                                           'authtype': 'default'}}],
                   name=HAWK_DW_PROVIDER_NAME,


### PR DESCRIPTION
This change adds the option to verify SSL certificates for a provider's endpoint.
The SSL verification between ManageIQ and the provider is enabled by default, and can be configured by passing `provider_verify_ssl` boolean parameter.
To use a self-signed certificate pass the ca file path option: `provider_ca_path: '/path/to/certfile'`

The change does not add this support in the update functionality since a provider authentication does not re-validate after endpoint update (open issue: https://github.com/ManageIQ/manageiq/issues/13167). Added a `TODO`