### PR TITLE
Fix the documentation inside the modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ ManageIQ Python API Client package [manageiq-client] (https://github.com/ManageI
 To try the modules copy and edit the relevant example playbook and execute:
 
     $ ansible-playbook examples/EDITED_PLAYBOOK.yml -M library/
+
+To view a module documentation execute:
+
+    $ ansible-doc --module-path=library/ MODULE_NAME.py
    
 
 

--- a/library/manageiq_custom_attributes.py
+++ b/library/manageiq_custom_attributes.py
@@ -8,6 +8,7 @@ from manageiq_client.api import ManageIQClient as MiqApi
 DOCUMENTATION = '''
 ---
 module: manageiq_custom_attributes
+description: The manageiq_custom_attributes module supports adding, updating and deleting custom attributes on resources in ManageIQ
 short_description: add, update, delete an entity custom attributes in ManageIQ
 requirements: [ ManageIQ/manageiq-api-client-python ]
 author: Daniel Korn (@dkorn)
@@ -38,8 +39,8 @@ options:
     description:
       - the state of the custom attributes
       - On present, it will add the custom attributes to the entity if not
-      already exist, or update the custom attributes if the associated data
-      is different
+        already exist, or update the custom attributes if the associated data
+        is different
       - On absent, it will delete the custom attributes from the entity if exist
     required: false
     choices: ['present', 'absent']

--- a/library/manageiq_policy_assignment.py
+++ b/library/manageiq_policy_assignment.py
@@ -8,6 +8,7 @@ from manageiq_client.api import ManageIQClient as MiqApi
 DOCUMENTATION = '''
 ---
 module: manageiq_policy
+description: The manageiq_policy_assignment module currently supports assigning and unassigning Policies and Policy Profiles on resources in ManageIQ
 short_description: assign and unassign policies and policy profiles on resources in ManageIQ
 requirements: [ ManageIQ/manageiq-api-client-python ]
 author: Daniel Korn (@dkorn)

--- a/library/manageiq_provider.py
+++ b/library/manageiq_provider.py
@@ -9,6 +9,7 @@ from manageiq_client.api import ManageIQClient as MiqApi
 DOCUMENTATION = '''
 ---
 module: manageiq_provider
+description: The manageiq_provider module currently supports adding, updating and deleting OpenShift, Amazon EC2 and Hawkular Datawarehouse providers to ManageIQ.
 short_description: add, update, delete provider in ManageIQ
 requirements: [ ManageIQ/manageiq-api-client-python ]
 author: Daniel Korn (@dkorn)
@@ -50,7 +51,7 @@ options:
     description:
       - the state of the provider
       - On present, it will add the provider if it does not exist or update the
-      provider if the associated data is different
+        provider if the associated data is different
       - On absent, it will delete the provider if it exists
     required: false
     choices: ['present', 'absent']
@@ -78,7 +79,7 @@ options:
   provider_verify_ssl:
     description:
       - whether SSL certificates should be verified for HTTPS requests between
-      ManageIQ and the provider
+        ManageIQ and the provider
     required: false
     default: True
     choices: ['True', 'False']

--- a/library/manageiq_user.py
+++ b/library/manageiq_user.py
@@ -4,6 +4,7 @@
 DOCUMENTATION = '''
 ---
 module: manageiq_user
+description: The manageiq_user module supports adding, updating and deleting users in ManageIQ.
 short_description: management of users in ManageIQ
 requirements: [ ManageIQ/manageiq-api-client-python ]
 author: Daniel Korn (@dkorn)
@@ -49,7 +50,7 @@ options:
     description:
       - the state of the user
       - On present, it will create the user if it does not exist or update the
-      user if the associated data is different
+        user if the associated data is different
       - On absent, it will delete the user if it exists
     required: false
     choices: ['present', 'absent']


### PR DESCRIPTION
Running `ansible-doc --module-path=library/ <module_name>.py` should output the module docs.
This change fixes few small issues preventing the docs display.

fixes: #56