### PR TITLE
Provider custom CA support backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `manageiq_provider` module currently supports adding, updating and deleting 
 Example playbooks [add_openshift_provider.yml](add_openshift_provider.yml), [add_amazon_provider.yml](add_amazon_provider.yml) and [add_hawkular_datawarehouse_provider.yml](add_hawkular_datawarehouse_provider.yml) are provided.
 To update an existing provider pass the changed values together with the required parameters. To delete a provider change `state=absent`.  
 SSL verification for HTTPS requests between ManageIQ and the provider is enabled by default. To ignore pass `provider_verify_ssl: false`.
-To use a self-signed certificate pass: `provider_ca_path: '/path/to/certfile'`.  
+To use a self-signed certificate pass: `provider_ca_path: '/path/to/certfile'`. To remove a previously defined ca pass `""` (empty string). In case the parameter is passed with null or omitted the `certificate_authority` field will be left unmodified (unset on creation). `provider_ca_path` must be omitted with ManageIQ Euwe / CFME 5.7 or earlier releases.
 After addition or update, each endpoint authentication is validated, a process which can take up to 50 seconds before timeout.
 If all authentications are valid the provider's inventory is refreshed.
 

--- a/tests/test_manageiq_provider.py
+++ b/tests/test_manageiq_provider.py
@@ -252,7 +252,7 @@ def test_generate_auth_key_config(miq):
                         'endpoint': {'hostname': PROVIDER_HOSTNAME,
                                      'port': PROVIDER_PORT,
                                      'role': 'default',
-                                     'certificate_authority': None,
+                                     'certificate_authority': "",
                                      'verify_ssl': PROVIDER_VERIFY_SSL}}
 
 
@@ -275,7 +275,7 @@ def test_will_add_openshift_provider_if_none_present(miq, miq_api_class, openshi
                                     'role': 'default',
                                     'hostname': PROVIDER_HOSTNAME,
                                     'verify_ssl': PROVIDER_VERIFY_SSL,
-                                    'certificate_authority': None},
+                                    'certificate_authority': ""},
                        'authentication': {'auth_key': PROVIDER_TOKEN,
                                           'authtype': 'bearer'}}],
                   name=PROVIDER_NAME,
@@ -335,7 +335,7 @@ def test_will_add_hawkular_datawarehose_provider_if_none_present(miq, miq_api_cl
                                     'role': 'default',
                                     'hostname': HAWK_DW_HOSTNAME,
                                     'verify_ssl': PROVIDER_VERIFY_SSL,
-                                    'certificate_authority': None},
+                                    'certificate_authority': ""},
                        'authentication': {'auth_key': HAWK_DW_PROVIDER_TOKEN,
                                           'authtype': 'default'}}],
                   name=HAWK_DW_PROVIDER_NAME,


### PR DESCRIPTION
Following a recent change in manageiq PR #55 added support for provider TLS and custom CA.
Adding a provider with an auth_key_config endpoint was failing on previous manageiq versions, due to unknown attribute 'certificate_authority'.

This change handles the issue, fixes: #61