### PR TITLE
Refactor: default state to 'present' in all modules

### DIFF
--- a/library/manageiq_custom_attributes.py
+++ b/library/manageiq_custom_attributes.py
@@ -42,7 +42,7 @@ options:
         already exist, or update the custom attributes if the associated data
         is different
       - On absent, it will delete the custom attributes from the entity if exist
-    required: false
+    required: False
     choices: ['present', 'absent']
     default: 'present'
   custom_attributes:
@@ -237,7 +237,7 @@ def main():
             entity_name=dict(required=True, type='str'),
             entity_type=dict(required=True, type='str',
                              choices=['provider', 'vm']),
-            state=dict(default='present',
+            state=dict(require=False, default='present',
                        choices=['present', 'absent']),
             custom_attributes=dict(required=True, type='list'),
             miq_url=dict(default=os.environ.get('MIQ_URL', None)),

--- a/library/manageiq_policy_assignment.py
+++ b/library/manageiq_policy_assignment.py
@@ -50,7 +50,7 @@ options:
     description:
       - On present, it will assign the entity on the resource, if not already assigned
       - On absent, it will unassign the entity from the resource
-    required: false
+    required: False
     choices: ['present', 'absent']
     default: 'present'
   miq_verify_ssl:
@@ -197,8 +197,8 @@ def main():
             resource=dict(required=True, type='str',
                           choices=['provider', 'host', 'vm', 'container node',
                                    'pod', 'replicator', 'container image']),
-            state=dict(required=True, type='str',
-                       choices=['present', 'absent']),
+            state=dict(required=False, type='str',
+                       choices=['present', 'absent'], default='present'),
             miq_url=dict(default=os.environ.get('MIQ_URL', None)),
             miq_username=dict(default=os.environ.get('MIQ_USERNAME', None)),
             miq_password=dict(default=os.environ.get('MIQ_PASSWORD', None), no_log=True),

--- a/library/manageiq_provider.py
+++ b/library/manageiq_provider.py
@@ -53,7 +53,7 @@ options:
       - On present, it will add the provider if it does not exist or update the
         provider if the associated data is different
       - On absent, it will delete the provider if it exists
-    required: false
+    required: False
     choices: ['present', 'absent']
     default: 'present'
   zone:
@@ -515,7 +515,7 @@ def main():
             zone=dict(required=False, type='str'),
             provider_type=dict(required=True,
                                choices=ManageIQProvider.PROVIDER_TYPES.keys()),
-            state=dict(default='present',
+            state=dict(required=False, default='present',
                        choices=['present', 'absent']),
             miq_url=dict(default=os.environ.get('MIQ_URL', None)),
             miq_username=dict(default=os.environ.get('MIQ_USERNAME', None)),

--- a/library/manageiq_tag_assignment.py
+++ b/library/manageiq_tag_assignment.py
@@ -46,9 +46,9 @@ options:
     description:
       - On present, it will assign the tag on the resource, if not already assigned
       - On absent, it will unassign the tag from the resource
-    required: true
+    required: False
     choices: ['present', 'absent']
-    default: null
+    default: 'present'
   miq_verify_ssl:
     description:
       - whether SSL certificates should be verified for HTTPS requests
@@ -193,8 +193,8 @@ def main():
                                    'cluster', 'data store', 'group', 'resource pool',
                                    'service', 'service template', 'template', 'tenant',
                                    'user']),
-            state=dict(required=True, type='str',
-                       choices=['present', 'absent']),
+            state=dict(required=False, type='str',
+                       choices=['present', 'absent'], default='present'),
             miq_url=dict(default=os.environ.get('MIQ_URL', None)),
             miq_username=dict(default=os.environ.get('MIQ_USERNAME', None)),
             miq_password=dict(default=os.environ.get('MIQ_PASSWORD', None), no_log=True),

--- a/library/manageiq_user.py
+++ b/library/manageiq_user.py
@@ -52,8 +52,9 @@ options:
       - On present, it will create the user if it does not exist or update the
         user if the associated data is different
       - On absent, it will delete the user if it exists
-    required: false
+    required: False
     choices: ['present', 'absent']
+    default: 'present'
   miq_verify_ssl:
     description:
       - whether SSL certificates should be verified for HTTPS requests
@@ -221,8 +222,8 @@ def main():
             password=dict(required=False, type='str', no_log=True),
             group=dict(required=False, type='str'),
             email=dict(required=False, type='str'),
-            state=dict(required=True, type='str',
-                       choices=['present', 'absent']),
+            state=dict(required=False, type='str',
+                       choices=['present', 'absent'], defualt='present'),
             miq_url=dict(default=os.environ.get('MIQ_URL', None)),
             miq_username=dict(default=os.environ.get('MIQ_USERNAME', None)),
             miq_password=dict(default=os.environ.get('MIQ_PASSWORD', None), no_log=True),


### PR DESCRIPTION
This change enforces a unified approach for the state parameter, not required and defaulted to present in all modules.
Few documentation fixes were needed.