### PR TITLE
Fix NameError in manageiq_tag_assignment module

### DIFF
--- a/library/manageiq_tag_assignment.py
+++ b/library/manageiq_tag_assignment.py
@@ -139,7 +139,7 @@ class ManageIQTagAssignment(object):
             if result['success']:
                 self.changed = True
             else:
-                self.module.fail_json(msg="Failed to {action}: {fail_message}".format(action=action, entity=entity, fail_message=result['message']))
+                self.module.fail_json(msg="Failed to {action}: {fail_message}".format(action=action, fail_message=result['message']))
 
     def full_tag_name(self, tag):
         """ Returns the full tag name in manageiq


### PR DESCRIPTION
There is no such var `entity` currently in the code.
This exception is obscuring other errors.

@pavelzag Please review