### PR TITLE
Initial commit for ovirt provider

### DIFF
--- a/examples/add_ovirt_provider.yml
+++ b/examples/add_ovirt_provider.yml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+
+  tasks:
+  - name: Add RHEV or ovirt provider to ManageIQ
+    manageiq_provider:
+      name: 'RHEV01'
+      provider_type: 'ovirt'
+      state: 'present'
+      provider_api_hostname: 'https://rhev.example.com'
+      provider_api_user: 'admin@internal'
+      provider_api_password: '******'
+      miq_url: 'http://miq.example.com'
+      miq_username: 'admin'
+      miq_password: '******'
+      miq_verify_ssl: false
+    register: result
+
+  - debug: var=result


### PR DESCRIPTION
Hello,

I recently had to create a number of providers using the uri module which was a bit painful.

Here is my first stab at adding RHEV/ovirt capability. I am not much of a coder so much of it is copy/paste. The relevant code which successfully created a RHEV provider from the uri module is:
```

- name: Create RHEV Provider
  uri:
    url: "https://{{ hostvars[groups['cfme_rhev'][0]]['inventory_hostname'] }}/api/providers"
    method: POST
    user: "{{ vault_cfme_user }}"
    password: "{{ vault_cfme_password }}"
    body: 
      type: "ManageIQ::Providers::Redhat::InfraManager"
      name: "{{ hostvars[groups['cfme_rhev'][0]]['rhev_name'] }}"
      hostname: "{{ hostvars[groups['rhev'][0]]['inventory_hostname'] }}"
      credentials:
        userid: "{{ vault_rhev_user }}"
        password: "{{ vault_rhev_password }}"
    status_code: 200
    body_format: json
    validate_certs: no
```
I don't have access to test this any more unfortunately but perhaps its a start?

Constructive criticism appreciated. I'll progress to OpenStack, Tower and Satellite if response is generally positive.